### PR TITLE
Skip numeric strings in translation

### DIFF
--- a/public/translator.js
+++ b/public/translator.js
@@ -218,6 +218,8 @@
     for (const it of allItems) {
       const src = it.kind === "text" ? it.node.nodeValue : it.value;
       if (it.kind === "text" && seen.get(it.node) === src) continue;
+      // Skip items that are purely numeric so they are not sent for translation
+      if (/^\s*[\d.,]+\s*$/.test(it.value)) continue;
       inputs.push(it.value);
       refs.push(it);
     }


### PR DESCRIPTION
## Summary
- prevent purely numeric text from being sent to Gemini by skipping such items in the translation queue

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b35fc5e308833299de466014cef4e6